### PR TITLE
More precise layer validity check

### DIFF
--- a/core/valuewidget.py
+++ b/core/valuewidget.py
@@ -259,7 +259,7 @@ class ValueWidget(QWidget, Ui_Widget):
                     layer.type()==QgsMapLayer.RasterLayer and \
                     layer.dataProvider() and \
                     (layer.dataProvider().capabilities() & QgsRasterDataProvider.IdentifyValue) and \
-                    (layer.dataProvider().xSize() & layer.dataProvider().ySize()):
+                    (layer.dataProvider().xSize() and layer.dataProvider().ySize()):
                 layers.append(layer)
             if layer.type() == QgsMapLayer.MeshLayer:
                 layer.createMapRenderer(QgsRenderContext())

--- a/core/valuewidget.py
+++ b/core/valuewidget.py
@@ -256,7 +256,7 @@ class ValueWidget(QWidget, Ui_Widget):
 
         for layer in allLayers:
             if layer!=None and layer.isValid() and \
-                    layer.type()==QgsMapLayer.RasterLayer and \
+                    layer.providerType() == "gdal" and \
                     layer.dataProvider() and \
                     (layer.dataProvider().capabilities() & QgsRasterDataProvider.IdentifyValue) and \
                     (layer.dataProvider().xSize() and layer.dataProvider().ySize()):


### PR DESCRIPTION
The current way (`layer.dataProvider().xSize() & layer.dataProvider().ySize()`) was returning 0 / False for some combinaison of raster width and height. Using `and` instead of `&` solve the issue:

Explanation:
```python
10 & 15  # return 10 / True
10 & 16  # return 0 / False

# In binary representation:
# 10 => 01010
# 15 => 01111
# 16 => 10000

# So a bitwise AND will return :
01010 & 01111  # return 01010 or simply 10 (once converted back to decimals) / True
01010 & 10000  # return 00000 or simply 0 / False

# But a logical AND will return:
10 and 15  # return 15 / True
10 and 16  # return 16 / True
```